### PR TITLE
support for sheet view options

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,31 @@ class ExampleSerializer(serializers.Serializer):
         return color_map.get(instance.alarm_level, 'FFFFFFFF')
 ```
 
+## Configuring Sheet View Options
+
+View options follow [openpyxl sheet view options](https://openpyxl.readthedocs.io/en/stable/_modules/openpyxl/worksheet/views.html#SheetView)
+
+They can be set in the view as a property `sheet_view_options`:
+
+```python
+class MyExampleViewSet(serializers.Serializer):
+    sheet_view_options = {
+        'rightToLeft': True, 
+        'showGridLines': False
+    }
+```
+
+or using method `get_sheet_view_options`:
+
+```python
+class MyExampleViewSet(serializers.Serializer):
+    
+    def get_sheet_view_options(self):
+        return {
+            'rightToLeft': True, 
+            'showGridLines': False
+        }
+```
 ## Controlling XLSX headers and values
 
 ### Use Serializer Field labels as header names

--- a/drf_excel/utilities.py
+++ b/drf_excel/utilities.py
@@ -53,6 +53,24 @@ class XLSXStyle(object):
         )
 
 
+def get_attribute(get_from, prop_name, default=None):
+    """
+    Get attribute from object with name <prop_name>, or take it from function get_<prop_name>
+    :param get_from: instance of object
+    :param prop_name: name of attribute (str)
+    :param default: what to return if attribute doesn't exist
+    :return: value of attribute <prop_name> or default
+    """
+    prop = getattr(get_from, prop_name, None)
+    if not prop:
+        prop_func = getattr(get_from, "get_{}".format(prop_name), None)
+        if prop_func:
+            prop = prop_func()
+    if prop is None:
+        prop = default
+    return prop
+
+
 def get_setting(key, default=None):
     return getattr(django_settings, "DRF_EXCEL_" + key, default)
 


### PR DESCRIPTION
Added support for sheet view options, things like `showGridLines`, `showRuler`, `rightToLeft` etc.
see https://openpyxl.readthedocs.io/en/stable/_modules/openpyxl/worksheet/views.html#SheetView for a list of options