### PR TITLE
Set correct media type

### DIFF
--- a/drf_excel/renderers.py
+++ b/drf_excel/renderers.py
@@ -38,7 +38,7 @@ class XLSXRenderer(BaseRenderer):
     Renderer for Excel spreadsheet open data format (xlsx).
     """
 
-    media_type = "application/xlsx"
+    media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     format = "xlsx"
     combined_header_dict = {}
     fields_dict = {}


### PR DESCRIPTION
according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` should be used. Closes #60