### PR TITLE
Remove usage of depreciated NullBooleanField for drf 3.14.0

### DIFF
--- a/drf_excel/renderers.py
+++ b/drf_excel/renderers.py
@@ -17,7 +17,6 @@ from rest_framework.fields import (
     FloatField,
     IntegerField,
     ListField,
-    NullBooleanField,
     TimeField,
 )
 from rest_framework.renderers import BaseRenderer
@@ -347,7 +346,7 @@ class XLSXRenderer(BaseRenderer):
             or self.custom_mappings.get(key),
             "cell_style": cell_style,
         }
-        if isinstance(field, BooleanField) or isinstance(field, NullBooleanField):
+        if isinstance(field, BooleanField):
             return XLSXBooleanField(boolean_display=self.boolean_display, **kwargs)
         elif (
             isinstance(field, IntegerField)


### PR DESCRIPTION
There is a new drf release https://www.django-rest-framework.org/community/release-notes/#3140 
Here `NullBooleanField` is no longer available and so I removed the one reference to allow support for drf 3.14.0


It was also not required as the `isinstance(field, BooleanField)` would return true for a `NullBooleanFIeld` due to object inheritance:
```python
>>> from rest_framework.fields import NullBooleanField
>>> field = NullBooleanField()
>>> from rest_framework.fields import BooleanField
>>> isinstance(field, BooleanField)
True
>>> 
```
So I think we should be good :+1:

Thank you for the package :heart: @FlipperPA 
