### PR TITLE
Update openpyxl requirements to compatiblity fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     zip_safe=False,
-    install_requires=["djangorestframework>=3.14", "openpyxl>=2.4"],
+    install_requires=["djangorestframework>=3.14", "openpyxl>=2.4,<3.1"],
     setup_requires=["setuptools_scm"],
     use_scm_version=True,
     classifiers=[


### PR DESCRIPTION
`drf_excel.renderers.XLSXRenderer` uses `openpyxl.writer.excel.save_virtual_workbook` which has been [deprecated](https://foss.heptapod.net/openpyxl/openpyxl/-/commit/3bb7ce5294c664e10e4db630f2651c40b6e50ca5) since 2018 and [removed](https://foss.heptapod.net/openpyxl/openpyxl/-/commit/45f0b4a85b563ff91b914278c2608e3b28dd16f0) in `openpyxl 3.1.0`

This is a temporary fix to solve dependency issues, but a proper fix should be to not use `save_virtual_workbook`