### PR TITLE
fix save_virtual_workbook deprecation/removal in openpyxl 3.1.0

### DIFF
--- a/drf_excel/renderers.py
+++ b/drf_excel/renderers.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Iterable, MutableMapping
+from tempfile import NamedTemporaryFile
 from typing import Dict
 
 from openpyxl import Workbook
@@ -7,7 +8,7 @@ from openpyxl.drawing.image import Image
 from openpyxl.styles import PatternFill
 from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.views import SheetView
-from openpyxl.writer.excel import save_virtual_workbook
+from openpyxl.writer.excel import save_workbook
 from rest_framework.fields import (
     BooleanField,
     DateField,
@@ -213,7 +214,17 @@ class XLSXRenderer(BaseRenderer):
         self.sheet_view_options = get_attribute(drf_view, "sheet_view_options", dict())
         self.ws.views.sheetView[0] = SheetView(**self.sheet_view_options)
 
-        return save_virtual_workbook(wb)
+        return self._save_virtual_workbook(wb)
+
+    def _save_virtual_workbook(self, wb):
+        tmp = NamedTemporaryFile()
+        save_workbook(wb, tmp.name)
+
+        tmp.seek(0)
+        virtual_workbook = tmp.read()
+        tmp.close()
+
+        return virtual_workbook
 
     def _check_validation_data(self, data):
         detail_key = "detail"


### PR DESCRIPTION
Fixes https://github.com/wharton/drf-excel/issues/73 

The proposed solution:
- replaces the call to `save_virtual_wookbook` by its non-deprecated version `save_wookbook`. 
- migrates the logic previously implemented in `save_virtual_wookbook` from openpyxl to this repository. 
- replaces the usage of `TemporaryFile` by `NamedTemporaryFile` as suggested by the openpyxl author on its deprecation message.

