### PR TITLE
fix(windows): replace NamedTemporaryFile with TemporaryFile

### DIFF
--- a/drf_excel/renderers.py
+++ b/drf_excel/renderers.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Iterable, MutableMapping
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryFile
 from typing import Dict
 
 from openpyxl import Workbook
@@ -215,12 +215,11 @@ class XLSXRenderer(BaseRenderer):
         return self._save_virtual_workbook(wb)
 
     def _save_virtual_workbook(self, wb):
-        tmp = NamedTemporaryFile()
-        save_workbook(wb, tmp.name)
-
-        tmp.seek(0)
-        virtual_workbook = tmp.read()
-        tmp.close()
+        with TemporaryFile() as tmp:
+            save_workbook(wb, tmp)
+            tmp.seek(0)
+            virtual_workbook = tmp.read()
+        
 
         return virtual_workbook
 


### PR DESCRIPTION
Hi there,

Thanks for creating & maintaining `drf-excel` 😃 

I'm running `drf` on `Windows Server 2019 (Datacenter)` for legacy/historical reasons.  This version blocks `NamedTemporaryFile` from saving to temp dir.  

> https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file

`TemporaryFile` seems to work fine across platforms in its place as it is not blocked by the dreaded permissions