### PR TITLE
fix support django lazy property

### DIFF
--- a/drf_excel/renderers.py
+++ b/drf_excel/renderers.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable, MutableMapping
 from tempfile import NamedTemporaryFile
 from typing import Dict
 
+from django.utils.functional import Promise
 from openpyxl import Workbook
 from openpyxl.drawing.image import Image
 from openpyxl.styles import PatternFill
@@ -303,6 +304,8 @@ class XLSXRenderer(BaseRenderer):
         items = []
         for k, v in data.items():
             new_key = f"{parent_key}{key_sep}{k}" if parent_key else k
+            if isinstance(v, Promise):
+                v = v.__class__._proxy____cast(v)
             if isinstance(v, MutableMapping):
                 items.extend(self._flatten_data(v, new_key, key_sep=key_sep).items())
             else:


### PR DESCRIPTION
Thank you for developing such an excellent plugin. I have found that when encountering django lazy loading, an error will be reported. The following example can reproduce this problem:

```python
from django.db import models
from django.utils.translation import gettext_lazy as _
class MyModel(models.Model):
    STATUS_CHOICES = (
        ('Created', _('Created')),
        ('Processing', _('Processing')),
        ('Finished', _('Finished')),
    )
    status = models.CharField(choices=STATUS_CHOICES)
    ...


from rest_framework import serializers
class MySerializers(serializers.ModelSerializer):
    status_display = serializers.CharField(source='get_status_display')

    class Meta:
        model = MyModel
        fields = ('status', 'status_display')
```
Only use `gettext_ Lazy` only has this issue, and `gettext` does not. I have analyzed that the reason for the problem is that `lazy` returned a obj of `__ proxy__`(a subclass of `Promise`) type , which is not a common data type.

I tried to fix this issue and submitted a merge request, which may not be elegant, but at least it works.