### PR TITLE
Fix Django classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Framework :: Django",
-    "Framework :: Django :: 3",
-    "Framework :: Django :: 4",
-    "Framework :: Django :: 5",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
 ]


### PR DESCRIPTION
Getting an error when trying to upload as it stands:

```
ERROR HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
'Framework :: Django :: 5' is not a valid classifier. See https://packaging.python.org/specifications/core-metadata for more information.
```

Looks like we need to specify the major and minor versions now: https://pypi.org/classifiers/